### PR TITLE
fix(manage-prefab): validate used nonexistent asset-db 'read-asset' message (#7)

### DIFF
--- a/source/test/manage-prefab.test.ts
+++ b/source/test/manage-prefab.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ManagePrefab } from '../tools/manage-prefab';
+
+describe('ManagePrefab', () => {
+    let tool: ManagePrefab;
+
+    beforeEach(() => {
+        tool = new ManagePrefab();
+        jest.clearAllMocks();
+    });
+
+    describe('metadata', () => {
+        it('has correct name', () => {
+            expect(tool.name).toBe('manage_prefab');
+        });
+
+        it('lists validate as an action', () => {
+            expect(tool.actions).toContain('validate');
+        });
+    });
+
+    describe('validate action (#7 — invalid asset-db "read-asset" message)', () => {
+        it('returns error when uuid is missing', async () => {
+            const result = await tool.execute('validate', {});
+            expect(result.success).toBe(false);
+        });
+
+        it('resolves the db url to a file path and reads it — never calls read-asset', async () => {
+            const tmpFile = path.join(os.tmpdir(), `t1k-prefab-${process.pid}-${Date.now()}.prefab`);
+            fs.writeFileSync(
+                tmpFile,
+                JSON.stringify([{ __type__: 'cc.Prefab' }, { __type__: 'cc.Node', _name: 'Root' }]),
+                'utf-8',
+            );
+            const mockRequest = (global as any).Editor.Message.request as jest.Mock;
+            mockRequest
+                .mockResolvedValueOnce({ url: 'db://assets/ScoreUI.prefab' }) // query-asset-meta
+                .mockResolvedValueOnce(tmpFile); // query-path
+
+            const result = await tool.execute('validate', { uuid: 'da1db047-660d-407c-9aa3-cab9b4d1141b' });
+
+            expect(result.success).toBe(true);
+            expect(result.data).toHaveProperty('isValid');
+            // The bug: the old code called a nonexistent 'read-asset' message.
+            expect(mockRequest).toHaveBeenCalledWith('asset-db', 'query-path', 'db://assets/ScoreUI.prefab');
+            const calledMessages = mockRequest.mock.calls.map((c: any[]) => c[1]);
+            expect(calledMessages).not.toContain('read-asset');
+
+            fs.unlinkSync(tmpFile);
+        });
+
+        it('errors clearly when the file path cannot be resolved on disk', async () => {
+            const mockRequest = (global as any).Editor.Message.request as jest.Mock;
+            mockRequest
+                .mockResolvedValueOnce({ url: 'db://assets/ScoreUI.prefab' }) // query-asset-meta
+                .mockResolvedValueOnce(null); // query-path returns nothing
+
+            const result = await tool.execute('validate', { uuid: 'some-uuid' });
+            expect(result.success).toBe(false);
+            expect(result.error).toMatch(/could not resolve prefab file path/i);
+        });
+
+        it('reports a parse error on malformed prefab JSON', async () => {
+            const tmpFile = path.join(os.tmpdir(), `t1k-prefab-bad-${process.pid}-${Date.now()}.prefab`);
+            fs.writeFileSync(tmpFile, 'not-json{', 'utf-8');
+            const mockRequest = (global as any).Editor.Message.request as jest.Mock;
+            mockRequest
+                .mockResolvedValueOnce({ url: 'db://assets/Bad.prefab' })
+                .mockResolvedValueOnce(tmpFile);
+
+            const result = await tool.execute('validate', { uuid: 'bad-uuid' });
+            expect(result.success).toBe(false);
+            expect(result.error).toMatch(/cannot parse json/i);
+
+            fs.unlinkSync(tmpFile);
+        });
+    });
+});

--- a/source/tools/manage-prefab.ts
+++ b/source/tools/manage-prefab.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { ActionToolResult, successResult, errorResult, PrefabInfo } from '../types';
 import { BaseActionTool } from './base-action-tool';
 import { normalizeVec3 } from '../utils/normalize';
@@ -349,8 +350,13 @@ export class ManagePrefab extends BaseActionTool {
             const assetInfo: any = await Editor.Message.request('asset-db', 'query-asset-meta', uuid);
             if (!assetInfo) return { success: false, error: 'Prefab not found' };
             const url = assetInfo.url || '';
+            // asset-db has no 'read-asset' message; resolve the db URL to a
+            // filesystem path and read the .prefab file directly (same pattern
+            // as manage-script / manage-animation).
+            const filePath = await Editor.Message.request('asset-db', 'query-path', url) as string | null;
+            if (!filePath) return { success: false, error: 'Could not resolve prefab file path on disk' };
             try {
-                const content: string = await Editor.Message.request('asset-db', 'read-asset', url);
+                const content: string = fs.readFileSync(filePath, 'utf-8');
                 try {
                     const prefabData = JSON.parse(content);
                     const validationResult = this.creationService.validatePrefabFormat(prefabData);


### PR DESCRIPTION
Fixes #7.

`manage_prefab validate` called `Editor.Message.request('asset-db', 'read-asset', url)`, but Cocos Creator's asset-db has no `read-asset` message — so validate on a valid prefab always failed with `Message does not exist: asset-db - read-asset`.

**Fix:** resolve the db URL to a filesystem path via `query-path`, then read the `.prefab` with `fs.readFileSync` — the established in-repo pattern (`manage-script.ts`, `manage-animation.ts`).

**Verification:** `npm run build` clean; full suite `28 suites / 544 tests` pass, including 6 new `manage-prefab` validate tests (happy path asserts `read-asset` is never called; plus unresolved-path and malformed-JSON cases).