### PR TITLE
fix: make dist/ line endings deterministic across platforms (#19)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize all text files to LF in the repository.
+# Without this, a Windows contributor's checkout re-commits CRLF and every
+# rebuilt dist/ file churns on the next cross-OS build (see issue #19).
+* text=auto eol=lf
+
+# Binary assets — never touch.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.zip binary
+
+# dist/ is generated. Keep it out of diffs/merge conflicts; rebuild with
+# `npm run build` rather than hand-resolving.
+dist/** -diff

--- a/base.tsconfig.json
+++ b/base.tsconfig.json
@@ -6,6 +6,7 @@
         "moduleResolution": "node",
         "inlineSourceMap": true,
         "inlineSources": true,
+        "newLine": "lf",
         "esModuleInterop": true,
         "skipLibCheck": true,
         "strict": true,


### PR DESCRIPTION
Fixes #19.

## What this does

1. **`.gitattributes`** — `* text=auto eol=lf`, binary asset carve-outs, and `dist/** -diff` so generated output stops bloating reviews.
2. **`base.tsconfig.json`** — adds `"newLine": "lf"`.

## Why the tsconfig line is the real fix

`tsconfig` had **no `newLine` setting**, so `tsc` emitted the platform default — LF on Linux/macOS, CRLF on Windows. That is the actual mechanism behind the churn: a Windows contributor running `npm run build` regenerates all 81 `dist/` files with CRLF and commits a diff that is 100% line endings.

`.gitattributes` cleans up after that happens; `"newLine": "lf"` stops it happening. Both are here, but the tsconfig setting is the SSOT.

## On renormalization — deliberately not done, because it isn't needed

The issue anticipated a `git add --renormalize .` sweep. That turns out to be a **verified no-op** on this repo:

- All **81/81** tracked `dist/` blobs in `HEAD` are already pure LF (checked the committed blobs via `git cat-file`, not the working tree).
- `git add --renormalize .` after adding `.gitattributes` stages **zero** files beyond the two intentional changes in this PR.

That is expected: renormalize rewrites the *index* to match `.gitattributes`, and since the blobs are already LF and `.gitattributes` targets LF, there is nothing to rewrite. This also means **no conflict with #17 or #20** — the concern that gated this fix behind them doesn't exist.

## Verification

```
npx tsc    → exit 0, `git status --porcelain dist/` empty (dist/ byte-identical)
npx jest   → 29 suites, 569 tests, all passing
```

The clean `tsc` round-trip is the meaningful check: it proves `"newLine": "lf"` matches what the committed `dist/` already contains, so this changes nothing for Linux/macOS contributors while making Windows match.

## Deliberately out of scope

The issue also raises `inlineSourceMap`/`inlineSources` (which embed the `.ts` source text, CRLF and all, into every emitted file). Switching to external source maps changes the debugging story, and the issue itself flags it as a separate call. With `newLine: "lf"` in place the embedded sources are LF anyway, so the churn is resolved without touching it.

## Follow-up worth considering

Neither this repo nor `unity-mcp` has CI, and this one commits `dist/`. A `npx tsc && git diff --exit-code dist/` drift gate plus `npm test` would be cheap insurance — `dist/` is what the Cocos editor actually loads, so drift there ships silently.
