### PR TITLE
fix(tools): set_property flags a reference that crosses a prefab-instance boundary

### DIFF
--- a/source/test/manage-component.test.ts
+++ b/source/test/manage-component.test.ts
@@ -586,4 +586,131 @@ describe('ManageComponent', () => {
             expect(result.error).toMatch(/did not verify/i);
         });
     });
+
+    // Regression: issue #48 — a node/component reference that crosses a prefab-instance
+    // boundary persists only as a cc.TargetOverrideInfo record on the instance's
+    // cc.PrefabInfo.targetOverrides. `scene:set-property` never creates one, and the
+    // post-write check re-reads the LIVE scene, so the write verified as
+    // `changeVerified: true` and was then silently lost on save. The result must now
+    // carry `persistenceVerified: false` + a warning for exactly that case — and must
+    // NOT do so for a reference that stays within one serialization context.
+    describe('set_property — prefab-instance boundary reporting (issue #48)', () => {
+        const HOST_NODE = 'host-node';
+        const HOST_TYPE = 'RefController';
+        const TARGET_NODE = 'target-node';
+
+        function hostDump() {
+            return {
+                __comps__: [
+                    {
+                        __type__: HOST_TYPE,
+                        type: HOST_TYPE,
+                        enabled: true,
+                        value: {
+                            uuid: { value: 'host-comp-uuid' },
+                            target: { name: 'target', value: null, type: 'cc.Node' }
+                        }
+                    }
+                ]
+            };
+        }
+
+        /**
+         * Wire a per-uuid `query-node` mock whose HOST dump reflects each `set-property`
+         * write (so live verification passes), and whose HOST/TARGET nodes carry the
+         * given `__prefab__` blocks — the discriminator ManagePrefab already drives
+         * apply-prefab/restore-prefab from.
+         */
+        function wire(hostPrefab: any, targetPrefab: any) {
+            const mockRequest = (global as any).Editor.Message.request as jest.Mock;
+            const host: any = hostDump();
+            if (hostPrefab) host.__prefab__ = hostPrefab;
+            const target: any = { __comps__: [] };
+            if (targetPrefab) target.__prefab__ = targetPrefab;
+
+            mockRequest.mockImplementation((_m: string, action: string, payload: any) => {
+                if (action === 'query-node') {
+                    return Promise.resolve(payload === TARGET_NODE ? target : host);
+                }
+                if (action === 'set-property') {
+                    const segments: string[] = payload.path.split('.');
+                    host.__comps__[Number(segments[1])].value[segments[2]].value = payload.dump.value;
+                    return Promise.resolve({});
+                }
+                return Promise.resolve({});
+            });
+            return mockRequest;
+        }
+
+        const setTarget = () => tool.execute('set_property', {
+            nodeUuid: HOST_NODE, componentType: HOST_TYPE,
+            property: 'target', propertyType: 'node', value: TARGET_NODE
+        });
+
+        it('flags a plain-scene component referencing a node inside a prefab instance', async () => {
+            wire(null, { rootUuid: 'instance-root', uuid: 'prefab-asset' });
+
+            const result = await setTarget();
+
+            expect(result.success).toBe(true);
+            expect(result.data.changeVerified).toBe(true);
+            expect(result.data.persistenceVerified).toBe(false);
+            expect(result.data.warning).toMatch(/cc\.TargetOverrideInfo/);
+        });
+
+        it('flags a component inside a prefab instance referencing a plain-scene node', async () => {
+            wire({ rootUuid: 'instance-root', uuid: 'prefab-asset' }, null);
+
+            const result = await setTarget();
+
+            expect(result.data.persistenceVerified).toBe(false);
+            expect(result.data.warning).toMatch(/prefab-instance boundary/);
+        });
+
+        it('does NOT flag a reference between two plain-scene nodes', async () => {
+            wire(null, null);
+
+            const result = await setTarget();
+
+            expect(result.success).toBe(true);
+            expect(result.data.changeVerified).toBe(true);
+            expect(result.data.persistenceVerified).toBeUndefined();
+            expect(result.data.warning).toBeUndefined();
+        });
+
+        it('does NOT flag a reference between two nodes inside the SAME prefab instance', async () => {
+            const sameInstance = { rootUuid: 'instance-root', uuid: 'prefab-asset' };
+            wire({ ...sameInstance }, { ...sameInstance });
+
+            const result = await setTarget();
+
+            expect(result.success).toBe(true);
+            expect(result.data.persistenceVerified).toBeUndefined();
+            expect(result.data.warning).toBeUndefined();
+        });
+
+        it('flags a reference between two DIFFERENT prefab instances', async () => {
+            wire({ rootUuid: 'instance-a', uuid: 'prefab-asset' }, { rootUuid: 'instance-b', uuid: 'prefab-asset' });
+
+            const result = await setTarget();
+
+            expect(result.data.persistenceVerified).toBe(false);
+            expect(result.data.warning).toBeDefined();
+        });
+
+        it('propagates the warning through set_properties_batch per-entry results', async () => {
+            wire(null, { rootUuid: 'instance-root', uuid: 'prefab-asset' });
+
+            const result = await tool.execute('set_properties_batch', {
+                nodeUuid: HOST_NODE, componentType: HOST_TYPE,
+                properties: [{ property: 'target', propertyType: 'node', value: TARGET_NODE }]
+            });
+
+            expect(result.success).toBe(true);
+            const entry = result.data.results[0];
+            expect(entry.success).toBe(true);
+            expect(entry.persistenceVerified).toBe(false);
+            expect(entry.warning).toMatch(/cc\.TargetOverrideInfo/);
+        });
+    });
 });

--- a/source/tools/manage-component-prefab-guard.ts
+++ b/source/tools/manage-component-prefab-guard.ts
@@ -1,0 +1,102 @@
+/**
+ * Prefab-instance boundary detection for component reference writes (issue #48).
+ *
+ * A reference that crosses a prefab-instance boundary does NOT persist through the
+ * normal serialized field. Cocos Creator stores it as a `cc.TargetOverrideInfo`
+ * record on the owning instance's `cc.PrefabInfo.targetOverrides`; the field itself
+ * serializes as `null` by design. `scene:set-property` writes only the live value —
+ * it creates no override record — so the write is real in memory, verifies against a
+ * live read-back, and is then lost on save.
+ *
+ * The post-write check in `applySingleProperty` re-reads the LIVE scene, so it cannot
+ * observe this class of loss by construction. This module supplies the missing signal:
+ * it does not change the write, it tells the caller the write may not survive a save.
+ *
+ * Detection uses the node dump's `__prefab__` block — the same discriminator
+ * `ManageComponent`'s sibling `ManagePrefab.resolvePrefabContext` already drives both
+ * `apply-prefab` and `restore-prefab` from.
+ */
+
+/** Reference propertyTypes whose value is one or more node UUIDs — the only ones that can cross a prefab boundary. */
+export const PREFAB_SENSITIVE_PROPERTY_TYPES = ['node', 'component', 'nodeArray', 'componentArray'] as const;
+
+export interface PrefabOverrideRisk {
+    /** True when the reference crosses a prefab-instance boundary and needs a cc.TargetOverrideInfo to survive a save. */
+    atRisk: boolean;
+    /** Caller-facing explanation. Present only when `atRisk`. */
+    warning?: string;
+}
+
+const WARNING =
+    'Live value set and verified, but this reference crosses a prefab-instance boundary. ' +
+    'A cross-prefab reference persists only as a cc.TargetOverrideInfo record on the instance\'s ' +
+    'cc.PrefabInfo.targetOverrides — this write does not create one, so the field may read back null ' +
+    'after the scene or prefab is saved. Verify the saved asset before relying on this reference.';
+
+/**
+ * Pull the referenced node UUIDs out of an already-converted property value.
+ * `convertPropertyValue` normalises `node`/`nodeArray` to `{ uuid }` shapes and
+ * `component`/`componentArray` to bare node-UUID strings, so both spellings land here.
+ */
+export function extractReferencedNodeUuids(propertyType: string, processedValue: any): string[] {
+    if (!(PREFAB_SENSITIVE_PROPERTY_TYPES as readonly string[]).includes(propertyType)) return [];
+
+    const items = Array.isArray(processedValue) ? processedValue : [processedValue];
+    const uuids: string[] = [];
+    for (const item of items) {
+        if (typeof item === 'string' && item) {
+            uuids.push(item);
+        } else if (item && typeof item === 'object' && typeof item.uuid === 'string' && item.uuid) {
+            uuids.push(item.uuid);
+        }
+    }
+    return uuids;
+}
+
+/**
+ * Identify the prefab instance a node belongs to, or null when it sits in plain scene space.
+ * Returns the instance ROOT uuid so two nodes inside the same instance compare equal.
+ * A query failure yields null — this check is advisory and must never break a write.
+ */
+async function prefabInstanceRoot(
+    nodeUuid: string,
+    queryNode: (uuid: string) => Promise<any>
+): Promise<string | null> {
+    let dump: any;
+    try {
+        dump = await queryNode(nodeUuid);
+    } catch {
+        return null;
+    }
+    const prefab = dump?.__prefab__;
+    if (!prefab) return null;
+    return prefab.rootUuid || nodeUuid;
+}
+
+/**
+ * Report whether a reference write crosses a prefab-instance boundary.
+ *
+ * At risk when the component's node and a referenced node resolve to DIFFERENT
+ * prefab-instance roots — including the plain-scene-to-instance and
+ * instance-to-plain-scene directions. Two nodes inside the same instance, and two
+ * nodes both outside any instance, serialize normally and are not flagged.
+ */
+export async function detectPrefabOverrideRisk(
+    nodeUuid: string,
+    propertyType: string,
+    processedValue: any,
+    queryNode: (uuid: string) => Promise<any>
+): Promise<PrefabOverrideRisk> {
+    const targetUuids = extractReferencedNodeUuids(propertyType, processedValue);
+    if (targetUuids.length === 0) return { atRisk: false };
+
+    const sourceRoot = await prefabInstanceRoot(nodeUuid, queryNode);
+    for (const targetUuid of targetUuids) {
+        if (targetUuid === nodeUuid) continue;
+        const targetRoot = await prefabInstanceRoot(targetUuid, queryNode);
+        if (targetRoot !== sourceRoot) {
+            return { atRisk: true, warning: WARNING };
+        }
+    }
+    return { atRisk: false };
+}

--- a/source/tools/manage-component.ts
+++ b/source/tools/manage-component.ts
@@ -3,6 +3,7 @@ import { BaseActionTool } from './base-action-tool';
 import { analyzeProperty, extractComponentPropertyDump, generateComponentSuggestion, convertPropertyValue, getAvailableComponentsList, redirectNodePropertyAccess, verifyComponentPropertyChange, SUPPORTED_PROPERTY_TYPES } from './manage-component-property-helpers';
 import { applyPropertyToEditor } from './manage-component-editor-apply';
 import { attachScriptToNode } from './manage-component-script-attach';
+import { detectPrefabOverrideRisk } from './manage-component-prefab-guard';
 
 export class ManageComponent extends BaseActionTool {
     readonly name = 'manage_component';
@@ -321,7 +322,10 @@ export class ManageComponent extends BaseActionTool {
             componentType,
             property,
             actualValue: fieldResult.actualValue,
-            changeVerified: fieldResult.changeVerified
+            changeVerified: fieldResult.changeVerified,
+            // Only present when the write crosses a prefab-instance boundary (issue #48):
+            // the live read-back verified, but the value may not survive a save.
+            ...(fieldResult.warning ? { persistenceVerified: fieldResult.persistenceVerified, warning: fieldResult.warning } : {})
         }, `Successfully set ${componentType}.${property}`);
     }
 
@@ -347,7 +351,7 @@ export class ManageComponent extends BaseActionTool {
             return resolution.result;
         }
 
-        const results: Array<{ property: string; success: boolean; actualValue?: any; changeVerified?: boolean; error?: string }> = [];
+        const results: Array<{ property: string; success: boolean; actualValue?: any; changeVerified?: boolean; persistenceVerified?: boolean; warning?: string; error?: string }> = [];
 
         for (const entry of properties) {
             const property = entry?.property;
@@ -373,7 +377,8 @@ export class ManageComponent extends BaseActionTool {
                     success: fieldResult.success,
                     actualValue: fieldResult.actualValue,
                     changeVerified: fieldResult.changeVerified,
-                    error: fieldResult.error
+                    error: fieldResult.error,
+                    ...(fieldResult.warning ? { persistenceVerified: fieldResult.persistenceVerified, warning: fieldResult.warning } : {})
                 });
             } catch (err: any) {
                 // Defensive: one bad field must never abort the batch.
@@ -500,7 +505,7 @@ export class ManageComponent extends BaseActionTool {
         targetComponent: any,
         rawComponentIndex: number,
         field: { property: string; propertyType: string; value: any }
-    ): Promise<{ success: boolean; actualValue?: any; changeVerified?: boolean; error?: string }> {
+    ): Promise<{ success: boolean; actualValue?: any; changeVerified?: boolean; persistenceVerified?: boolean; warning?: string; error?: string }> {
         const { property, propertyType, value } = field;
         try {
             console.log(`[ManageComponent] Setting ${componentType}.${property} (type: ${propertyType}) = ${JSON.stringify(value)} on node ${nodeUuid}`);
@@ -545,6 +550,22 @@ export class ManageComponent extends BaseActionTool {
                     actualValue: verification.actualValue,
                     changeVerified: false,
                     error: `Property '${componentType}.${property}' write did not verify: expected ${JSON.stringify(actualExpectedValue)} but the editor reads back ${JSON.stringify(verification.actualValue)}`
+                };
+            }
+
+            // Issue #48: verification above re-read the LIVE scene, which cannot observe a
+            // reference lost at serialization. A reference crossing a prefab-instance boundary
+            // needs a cc.TargetOverrideInfo record that `scene:set-property` never creates, so
+            // report the write as live-verified but NOT persistence-verified rather than
+            // returning a bare changeVerified:true the caller would read as durable.
+            const prefabRisk = await detectPrefabOverrideRisk(
+                nodeUuid, propertyType, processedValue,
+                (uuid: string) => Editor.Message.request('scene', 'query-node', uuid)
+            );
+            if (prefabRisk.atRisk) {
+                return {
+                    success: true, actualValue: verification.actualValue, changeVerified: true,
+                    persistenceVerified: false, warning: prefabRisk.warning
                 };
             }
 


### PR DESCRIPTION
## What

`manage_component set_property` / `set_properties_batch` now report `persistenceVerified: false` plus a warning when a node/component reference crosses a prefab-instance boundary, instead of returning a bare `changeVerified: true` the caller reads as durable.

## Why

A reference whose two ends sit in different serialization contexts persists **only** as a `cc.TargetOverrideInfo` record on the owning instance's `cc.PrefabInfo.targetOverrides`; the component field itself serializes as `null` by design. `scene:set-property` writes the live value and creates no such record, and `applySingleProperty`'s post-write check re-reads the **live** scene — so this loss class is undetectable by that check *by construction*. The write verified, then vanished on save, with nothing in the result to say so.

## Which option I picked, and why

Three strategies were open:

| Option | Verdict |
|---|---|
| **A — detect + report (this PR)** | Additive fields only, no behaviour change on the write path, no editor required. **Picked.** |
| B — create the `cc.TargetOverrideInfo` via `execute-scene-script` | Needs a live Cocos Creator 3.8.7 round-trip. A malformed record yields a `PrefabInfo` the editor cannot parse — strictly worse than today's silent null. Not shippable unverified. |
| C — fail the write when a boundary is detected | Breaking; rejects writes that callers legitimately make and repair by hand. |

A is the smallest blast radius that fully addresses the reported defect's actionable half ("verification must survive a save, or warn"). It stands alone and delivers value with no TODO. Option B remains open as a follow-up **gated on a live-editor round-trip**; it is deliberately not in this change.

Because the outstanding isolation experiment (does the fault follow `propertyType=node`, or the source component being mounted inside an instance?) needs a live editor I do not have, the detection is deliberately **hypothesis-agnostic**: it flags a boundary crossing in *either* direction, so it cannot false-negative on whichever cause the experiment eventually confirms.

## How detection works

Reads the node dump's `__prefab__` block — the same discriminator `ManagePrefab.resolvePrefabContext` (`source/tools/manage-prefab.ts:348-365`) already drives `apply-prefab` / `restore-prefab` from — and compares the prefab-instance **root** uuid of the component's node against each referenced node's.

- different roots (including plain-scene ↔ instance, and instance-A ↔ instance-B) → flagged
- same instance, or both plain-scene → not flagged, result unchanged
- query failure → degrades to "not at risk"; this check is advisory and never blocks a write

## Evidence / what I verified

- `git grep -ni targetoverride -- source/` on `origin/main` returns exactly one hit — a hardcoded `"targetOverrides": null` in `manage-prefab-creation-service.ts:351`. No override is created, read, or checked anywhere on the write path. Defect confirmed present.
- `source/tools/manage-component.ts` had zero prefab awareness before this change.
- **Correction to the triage brief:** it proposed detecting via `__editorExtras__.mountedRoot` / `_prefab.instance`. Neither appears anywhere in this repo's node-dump handling. `__prefab__` is what the codebase actually reads and what `manage-prefab.test.ts` mocks, so I used that. Source won over the brief.
- Tests pin the **failure** state, not just success: reverting `manage-component.ts` alone turns **4 of the 6** new tests red (the two "does NOT flag" cases stay green in both directions on purpose — they are the identity-based companion guarding against over-flagging).
- Full suite green: **39 suites, 698 tests, 0 failures**. `tsc --noEmit` clean. No pre-existing failures observed.

Fixes #48

t1k-claim: The1Studio/cocos-mcp-server#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011k2Ayspd1FcbrfEZHJDB6u