### PR TITLE
fix(tools): serialize scene tool calls so a save cannot drop a concurrent node create (#6)

### DIFF
--- a/source/mcp-server.ts
+++ b/source/mcp-server.ts
@@ -46,6 +46,7 @@ import { ManageProfiler } from './tools/manage-profiler';
 import { ManageVideo } from './tools/manage-video';
 import { ManageInput } from './tools/manage-input';
 import { CocosResources } from './resources/cocos-resources';
+import { enqueueMutation } from './tools/mutation-queue';
 
 const MAX_BODY_SIZE = 1024 * 1024; // 1MB request body limit
 
@@ -196,7 +197,17 @@ export class MCPServer {
                 `Available actions: ${executor.actions.join(', ')}`
             );
         }
-        return await executor.execute(action, restArgs);
+        // #6: tool calls issued concurrently by a client interleave inside the editor, so a
+        // save can run while a `manage_node create` is still committing and silently drop it.
+        // Serializing every call on one chain here — the single dispatch point every tool
+        // call passes through — is what prevents that race; verifying the save afterwards
+        // only detects it. Re-entrant tools run directly: batch_execute calls back into this
+        // method per entry, so enqueueing it would deadlock it behind its own slot, and its
+        // inner calls are each serialized on their own anyway.
+        if (executor.reentrant) {
+            return await executor.execute(action, restArgs);
+        }
+        return await enqueueMutation(() => executor.execute(action, restArgs));
     }
 
     public getAvailableTools(): ToolDefinition[] {

--- a/source/test/manage-node-commit-wait.test.ts
+++ b/source/test/manage-node-commit-wait.test.ts
@@ -1,0 +1,70 @@
+import { ManageNode } from '../tools/manage-node';
+
+/**
+ * #6 — after `scene:create-node`, the follow-up set-parent / create-component /
+ * initial-transform steps waited out a fixed 100-150ms sleep and then proceeded whether or
+ * not the node had actually committed. On a slow editor it had not, and those edits were
+ * silently dropped. The wait is now a poll of `scene:query-node`.
+ */
+describe('ManageNode.create commit wait (#6)', () => {
+    let tool: ManageNode;
+    let mockRequest: jest.Mock;
+
+    beforeEach(() => {
+        tool = new ManageNode();
+        mockRequest = (global as any).Editor.Message.request as jest.Mock;
+        mockRequest.mockReset();
+    });
+
+    afterEach(() => {
+        mockRequest.mockReset();
+        mockRequest.mockResolvedValue({});
+    });
+
+    /**
+     * `queryNodeVisibleAfterMs` models the editor's commit latency: `query-node` returns
+     * nothing until that much time has passed since create-node resolved.
+     */
+    function routeCreate(queryNodeVisibleAfterMs: number, log: string[]) {
+        let createdAt = 0;
+        mockRequest.mockImplementation(async (_pkg: string, message: string) => {
+            log.push(message);
+            switch (message) {
+                case 'create-node':
+                    createdAt = Date.now();
+                    return 'node-uuid-1';
+                case 'query-node':
+                    if (Date.now() - createdAt < queryNodeVisibleAfterMs) return null;
+                    return { uuid: { value: 'node-uuid-1' }, name: { value: 'X' }, __comps__: [] };
+                default:
+                    return {};
+            }
+        });
+    }
+
+    it('adds components only after the node is actually queryable', async () => {
+        const log: string[] = [];
+        routeCreate(120, log);
+
+        const result = await tool.execute('create', { name: 'X', components: ['cc.Sprite'] });
+
+        expect(result.success).toBe(true);
+        // The component was created, and only after query-node first succeeded.
+        const firstSuccessfulQuery = log.indexOf('query-node');
+        expect(log.indexOf('create-component')).toBeGreaterThan(firstSuccessfulQuery);
+        // Polling means more than one query-node round trip while the editor was catching up.
+        expect(log.filter(m => m === 'query-node').length).toBeGreaterThan(1);
+    });
+
+    it('does not silently proceed when the node never becomes queryable', async () => {
+        const log: string[] = [];
+        // Never visible within the 2000ms budget.
+        routeCreate(60000, log);
+
+        const result = await tool.execute('create', { name: 'X', components: ['cc.Sprite'] });
+
+        // Create itself still reports (the node UUID exists); the dropped component is not
+        // pretended into existence by a create-component fired at a node that is not there.
+        expect(log).not.toContain('create-component');
+    }, 20000);
+});

--- a/source/test/manage-scene-query-dirty.test.ts
+++ b/source/test/manage-scene-query-dirty.test.ts
@@ -1,0 +1,69 @@
+import { ManageSceneQuery } from '../tools/manage-scene-query';
+import { enqueueMutation, resetMutationQueue } from '../tools/mutation-queue';
+
+/**
+ * #6 — `query_dirty` proxied `scene:query-dirty` verbatim. The editor flag only covers
+ * edits it has already committed, so a scene with mutating calls still queued reported
+ * `dirty: false` — "clean" — and a caller trusting that skipped the save it needed.
+ */
+describe('ManageSceneQuery.query_dirty (#6)', () => {
+    let tool: ManageSceneQuery;
+    let mockRequest: jest.Mock;
+
+    beforeEach(() => {
+        resetMutationQueue();
+        tool = new ManageSceneQuery();
+        mockRequest = (global as any).Editor.Message.request as jest.Mock;
+        mockRequest.mockReset();
+    });
+
+    afterEach(() => {
+        mockRequest.mockReset();
+        mockRequest.mockResolvedValue({});
+    });
+
+    it('reports clean only when the editor flag is false AND nothing is queued', async () => {
+        mockRequest.mockResolvedValue(false);
+
+        const result = await tool.execute('query_dirty', {});
+
+        expect(result.success).toBe(true);
+        expect(result.data.dirty).toBe(false);
+        expect(result.data.editorDirty).toBe(false);
+        expect(result.data.pendingMutations).toBe(0);
+    });
+
+    it('reports dirty when calls are still queued even though the editor flag reads false', async () => {
+        mockRequest.mockResolvedValue(false);
+
+        // Hold the queue open so the two calls behind it are genuinely still pending.
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => { release = resolve; });
+        const held = enqueueMutation(async () => { await gate; });
+        const queued = [
+            enqueueMutation(async () => undefined),
+            enqueueMutation(async () => undefined),
+        ];
+        await new Promise(r => setTimeout(r, 0));
+
+        const result = await tool.execute('query_dirty', {});
+
+        expect(result.data.dirty).toBe(true);
+        expect(result.data.editorDirty).toBe(false);
+        expect(result.data.pendingMutations).toBe(2);
+        expect(result.message).toMatch(/still queued/i);
+
+        release();
+        await Promise.all([held, ...queued]);
+    });
+
+    it('still reports dirty from the editor flag alone', async () => {
+        mockRequest.mockResolvedValue(true);
+
+        const result = await tool.execute('query_dirty', {});
+
+        expect(result.data.dirty).toBe(true);
+        expect(result.data.editorDirty).toBe(true);
+        expect(result.message).toMatch(/unsaved changes/i);
+    });
+});

--- a/source/test/mcp-server-serialization.test.ts
+++ b/source/test/mcp-server-serialization.test.ts
@@ -1,0 +1,93 @@
+import { MCPServer } from '../mcp-server';
+import { resetMutationQueue } from '../tools/mutation-queue';
+
+/**
+ * #6 — `manage_scene save` reported success while a concurrently issued `manage_node
+ * create` was still committing, so the created node was never written. Reproduces the
+ * report's caller pattern at the dispatch point: two tool calls fired together without
+ * awaiting the first. Before every tool call was serialized, `save-scene` ran while
+ * `create-node` was still pending.
+ */
+describe('MCPServer.executeToolCall serialization (#6)', () => {
+    const settings = {
+        port: 0,
+        autoStart: false,
+        enableDebugLog: false,
+        allowedOrigins: [],
+        maxConnections: 1,
+    };
+
+    let server: MCPServer;
+    let mockRequest: jest.Mock;
+    let messageLog: string[];
+
+    beforeEach(() => {
+        resetMutationQueue();
+        server = new MCPServer(settings);
+        messageLog = [];
+        mockRequest = (global as any).Editor.Message.request as jest.Mock;
+        mockRequest.mockReset();
+    });
+
+    afterEach(() => {
+        mockRequest.mockReset();
+        mockRequest.mockResolvedValue({});
+    });
+
+    it('does not start a save while a concurrently issued node create is still committing', async () => {
+        let createCommitted = false;
+        let savedWhileCreatePending = false;
+
+        mockRequest.mockImplementation(async (_pkg: string, message: string) => {
+            messageLog.push(message);
+            switch (message) {
+                case 'create-node':
+                    // The editor commits the node asynchronously — this is the window the
+                    // report's concurrent save slipped into.
+                    await new Promise(r => setTimeout(r, 30));
+                    createCommitted = true;
+                    return 'node-uuid-1';
+                case 'query-node':
+                    return createCommitted ? { uuid: { value: 'node-uuid-1' }, name: { value: 'X' } } : null;
+                case 'save-scene':
+                    if (!createCommitted) savedWhileCreatePending = true;
+                    return true;
+                case 'query-dirty':
+                    return false;
+                default:
+                    return {};
+            }
+        });
+
+        const create = server.executeToolCall('manage_node', { action: 'create', name: 'X' });
+        const save = server.executeToolCall('manage_scene', { action: 'save' });
+        const [createResult, saveResult] = await Promise.all([create, save]);
+
+        expect(savedWhileCreatePending).toBe(false);
+        expect(messageLog.indexOf('save-scene')).toBeGreaterThan(messageLog.indexOf('create-node'));
+        expect(createResult.success).toBe(true);
+        expect(saveResult.success).toBe(true);
+    });
+
+    it('runs batch_execute without deadlocking it behind its own queue slot', async () => {
+        mockRequest.mockImplementation(async (_pkg: string, message: string) => {
+            messageLog.push(message);
+            if (message === 'save-scene') return true;
+            if (message === 'query-dirty') return false;
+            return {};
+        });
+
+        // batch_execute re-enters executeToolCall for each call: enqueueing it would park it
+        // behind a slot only its own inner calls can release. It opts out via `reentrant`.
+        const result = await server.executeToolCall('batch_execute', {
+            action: 'execute',
+            calls: [
+                { tool: 'manage_scene', action: 'save' },
+                { tool: 'manage_scene', action: 'save' },
+            ],
+        });
+
+        expect(result.success).toBe(true);
+        expect(messageLog.filter(m => m === 'save-scene')).toHaveLength(2);
+    });
+});

--- a/source/test/mutation-queue.test.ts
+++ b/source/test/mutation-queue.test.ts
@@ -1,0 +1,59 @@
+import { enqueueMutation, pendingMutationCount, resetMutationQueue } from '../tools/mutation-queue';
+
+/**
+ * #6 — concurrent scene calls interleaved inside the editor, so a save could run while a
+ * `manage_node create` was still committing and silently drop it. The queue is the
+ * primitive that prevents that interleaving.
+ */
+describe('mutation-queue (#6)', () => {
+    beforeEach(() => {
+        resetMutationQueue();
+    });
+
+    it('runs concurrently enqueued calls one at a time, in enqueue order', async () => {
+        const events: string[] = [];
+        const slow = (label: string, delayMs: number) => enqueueMutation(async () => {
+            events.push(`${label}:start`);
+            await new Promise(r => setTimeout(r, delayMs));
+            events.push(`${label}:end`);
+            return label;
+        });
+
+        // Fired together and NOT awaited in turn — exactly the caller pattern #6 reproduces.
+        // Unserialized, 'create' (slower) would still be running when 'save' starts.
+        const results = await Promise.all([slow('create', 30), slow('save', 0)]);
+
+        expect(results).toEqual(['create', 'save']);
+        expect(events).toEqual(['create:start', 'create:end', 'save:start', 'save:end']);
+    });
+
+    it('releases the queue when a call rejects, and propagates that rejection', async () => {
+        const failing = enqueueMutation(async () => { throw new Error('editor rejected the call'); });
+        const following = enqueueMutation(async () => 'ran anyway');
+
+        await expect(failing).rejects.toThrow('editor rejected the call');
+        await expect(following).resolves.toBe('ran anyway');
+    });
+
+    it('counts calls still queued behind the running one, and excludes the running one', async () => {
+        let observedFromInside = -1;
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => { release = resolve; });
+
+        const first = enqueueMutation(async () => {
+            observedFromInside = pendingMutationCount();
+            await gate;
+        });
+        const second = enqueueMutation(async () => undefined);
+        const third = enqueueMutation(async () => undefined);
+
+        // Let `first` reach its body before asserting.
+        await new Promise(r => setTimeout(r, 0));
+        expect(pendingMutationCount()).toBe(2);
+        expect(observedFromInside).toBe(2);
+
+        release();
+        await Promise.all([first, second, third]);
+        expect(pendingMutationCount()).toBe(0);
+    });
+});

--- a/source/tools/batch-execute.ts
+++ b/source/tools/batch-execute.ts
@@ -26,6 +26,8 @@ export class BatchExecute extends BaseActionTool {
     readonly name = 'batch_execute';
     readonly description = 'Execute multiple tool calls sequentially in a single request. Reduces round-trips when building complex scenes. Actions: execute. Max 50 calls per batch. Each call specifies tool name, action, and args. Use stopOnError=false to continue past failures.';
     readonly actions = ['execute'];
+    /** Re-enters the dispatcher for each of its own calls — must not be enqueued (#6). */
+    readonly reentrant = true;
 
     readonly inputSchema = {
         type: 'object',

--- a/source/tools/manage-node.ts
+++ b/source/tools/manage-node.ts
@@ -3,6 +3,11 @@ import { ActionToolResult, NodeInfo, successResult, errorResult } from '../types
 import { coerceBool, coerceInt, coerceFloat, normalizeVec3 } from '../utils/normalize';
 import { is2DNode, is2DComponentType, is3DComponentType, normalizeTransformValue, getComponentCategory, getNodePath, searchNodeInTree } from './manage-node-transform-helpers';
 
+/** Longest `awaitNodeCommit` waits for a freshly created node to become queryable. */
+const NODE_COMMIT_TIMEOUT_MS = 2000;
+/** Gap between `scene:query-node` polls while waiting for that commit. */
+const NODE_COMMIT_POLL_MS = 20;
+
 export class ManageNode extends BaseActionTool {
 
     readonly name = 'manage_node';
@@ -242,7 +247,7 @@ export class ManageNode extends BaseActionTool {
 
             if (siblingIndex !== undefined && siblingIndex >= 0 && uuid && targetParentUuid) {
                 try {
-                    await new Promise(r => setTimeout(r, 100));
+                    await this.awaitNodeCommit(uuid);
                     await Editor.Message.request('scene', 'set-parent', {
                         parent: targetParentUuid,
                         uuids: [uuid],
@@ -263,7 +268,7 @@ export class ManageNode extends BaseActionTool {
 
             if (args.components && args.components.length > 0 && uuid) {
                 try {
-                    await new Promise(r => setTimeout(r, 100));
+                    await this.awaitNodeCommit(uuid);
                     for (const componentType of args.components) {
                         try {
                             await Editor.Message.request('scene', 'create-component', {
@@ -282,7 +287,7 @@ export class ManageNode extends BaseActionTool {
 
             if (args.initialTransform && uuid) {
                 try {
-                    await new Promise(r => setTimeout(r, 150));
+                    await this.awaitNodeCommit(uuid);
                     const pos = normalizeVec3(args.initialTransform.position);
                     const rot = normalizeVec3(args.initialTransform.rotation);
                     const scl = normalizeVec3(args.initialTransform.scale);
@@ -335,6 +340,31 @@ export class ManageNode extends BaseActionTool {
 
         } catch (err: any) {
             return errorResult(`Failed to create node: ${err.message}. Args: ${JSON.stringify(args)}`);
+        }
+    }
+
+    /**
+     * `scene:create-node` resolves before the new node is queryable, so the follow-up
+     * set-parent / create-component / initial-transform steps used to wait out a fixed
+     * 100-150ms sleep and then proceed regardless of whether the commit had landed. On a
+     * busy editor it had not, and those edits were silently dropped from the created node
+     * (#6). Poll `scene:query-node` instead: continue as soon as the node is actually
+     * visible, and throw when it never becomes visible so the caller's existing catch
+     * reports a real reason rather than a blind failure further down.
+     */
+    private async awaitNodeCommit(uuid: string): Promise<void> {
+        const deadline = Date.now() + NODE_COMMIT_TIMEOUT_MS;
+        for (;;) {
+            try {
+                const nodeData: any = await Editor.Message.request('scene', 'query-node', uuid);
+                if (nodeData) return;
+            } catch (err) {
+                // query-node rejects while the node is not yet in the graph — keep polling.
+            }
+            if (Date.now() >= deadline) {
+                throw new Error(`Node '${uuid}' was not queryable within ${NODE_COMMIT_TIMEOUT_MS}ms of creation`);
+            }
+            await new Promise(r => setTimeout(r, NODE_COMMIT_POLL_MS));
         }
     }
 

--- a/source/tools/manage-scene-query.ts
+++ b/source/tools/manage-scene-query.ts
@@ -1,5 +1,6 @@
 import { BaseActionTool } from './base-action-tool';
 import { ActionToolResult, successResult, errorResult } from '../types';
+import { pendingMutationCount } from './mutation-queue';
 
 export class ManageSceneQuery extends BaseActionTool {
     readonly name = 'manage_scene_query';
@@ -97,10 +98,25 @@ export class ManageSceneQuery extends BaseActionTool {
         });
     }
 
+    /**
+     * `scene:query-dirty` only describes edits the editor has already committed. Mutating
+     * tool calls the client issued but that are still queued behind this query have not
+     * reached the editor yet, so proxying the raw flag reported `dirty: false` — "clean" —
+     * for a scene that was about to change, and a caller trusting it skipped the save it
+     * actually needed (#6). Reconcile the flag against the serialization queue and report
+     * both readings so a caller can see *why* the scene is dirty.
+     */
     private async queryDirty(): Promise<ActionToolResult> {
         return new Promise((resolve) => {
-            Editor.Message.request('scene', 'query-dirty').then((dirty: boolean) => {
-                resolve(successResult({ dirty }, dirty ? 'Scene has unsaved changes' : 'Scene is clean'));
+            Editor.Message.request('scene', 'query-dirty').then((editorDirty: boolean) => {
+                const pendingMutations = pendingMutationCount();
+                const dirty = editorDirty === true || pendingMutations > 0;
+                const message = !dirty
+                    ? 'Scene is clean'
+                    : pendingMutations > 0
+                        ? `Scene has ${pendingMutations} tool call(s) still queued — treat as dirty`
+                        : 'Scene has unsaved changes';
+                resolve(successResult({ dirty, editorDirty: editorDirty === true, pendingMutations }, message));
             }).catch((err: Error) => {
                 resolve(errorResult(err.message));
             });

--- a/source/tools/manage-scene.ts
+++ b/source/tools/manage-scene.ts
@@ -126,11 +126,14 @@ export class ManageScene extends BaseActionTool {
      * A `false` result is now treated as a failed save (#6).
      *
      * A resolved `true` still does not guarantee every pending edit was captured — two
-     * mutating calls issued concurrently/batched (rather than awaited sequentially) can
-     * race with the save, per #6's own reproduction. `scene:query-dirty` (already used by
-     * `manage_scene_query`) is checked immediately after: a scene still reporting dirty
-     * right after a "successful" save is direct evidence something did not make it into
-     * that save, and is now surfaced as an actionable failure instead of silent success.
+     * mutating calls issued concurrently/batched (rather than awaited sequentially) could
+     * race with the save, per #6's own reproduction. That race is now prevented upstream:
+     * every tool call is serialized on one chain (`tools/mutation-queue.ts`), so this save
+     * cannot begin until the mutations ahead of it have settled. `scene:query-dirty`
+     * (already used by `manage_scene_query`) is still checked immediately after as the
+     * backstop: a scene reporting dirty right after a "successful" save is direct evidence
+     * something did not make it into that save, and is surfaced as an actionable failure
+     * instead of silent success.
      */
     private async saveScene(): Promise<ActionToolResult> {
         return new Promise((resolve) => {

--- a/source/tools/mutation-queue.ts
+++ b/source/tools/mutation-queue.ts
@@ -1,0 +1,88 @@
+/**
+ * Global serialization queue for scene-mutating editor calls (#6).
+ *
+ * `Editor.Message.request` calls issued concurrently interleave inside the editor: a
+ * caller that fires `manage_node create` and `manage_scene save` in the same batch (rather
+ * than awaiting the create first) can have the save run against a scene graph the create
+ * has not finished committing to. The save then reports success while the created node is
+ * never written — the data loss reported in #6. Verifying the save afterwards (the #59
+ * fix) detects that after the fact; only serializing the calls prevents it.
+ *
+ * Every tool call is chained onto one promise tail, so at most one is in flight at a time
+ * and a save cannot begin until the mutations ahead of it have settled. The chain is not
+ * a lock a caller can hold across calls — it is released as soon as the enqueued function
+ * settles, whether it resolves or rejects.
+ */
+
+/** Longest a queued call waits for its turn before proceeding unserialized. */
+export const QUEUE_WAIT_TIMEOUT_MS = 120000;
+
+/** Tail of the chain. Resolves when the most recently enqueued call has settled. */
+let tail: Promise<void> = Promise.resolve();
+/** Enqueued and waiting for a turn — excludes the call currently running. */
+let queuedCount = 0;
+
+/**
+ * Waits for `predecessor` to settle, but never longer than {@link QUEUE_WAIT_TIMEOUT_MS}.
+ * A tool whose editor request never settles would otherwise wedge the whole queue and
+ * take every later call down with it, which is a worse failure than the race being fixed.
+ * Never rejects — a rejected predecessor is still a released slot.
+ */
+function settleOrTimeout(predecessor: Promise<void>): Promise<void> {
+    return new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = (timedOut: boolean) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            if (timedOut) {
+                console.warn(
+                    `[mutation-queue] Previous scene call did not settle within ${QUEUE_WAIT_TIMEOUT_MS}ms; ` +
+                    'proceeding unserialized to keep the server responsive.'
+                );
+            }
+            resolve();
+        };
+        const timer = setTimeout(() => finish(true), QUEUE_WAIT_TIMEOUT_MS);
+        if (typeof (timer as any).unref === 'function') (timer as any).unref();
+        predecessor.then(() => finish(false), () => finish(false));
+    });
+}
+
+/**
+ * Runs `fn` once every call enqueued before it has settled. Returns whatever `fn` returns,
+ * and propagates its rejection unchanged — enqueueing must be invisible to the caller
+ * apart from the ordering it guarantees.
+ */
+export function enqueueMutation<T>(fn: () => Promise<T>): Promise<T> {
+    const predecessor = tail;
+    let release: () => void = () => {};
+    tail = new Promise<void>((resolve) => { release = resolve; });
+    queuedCount++;
+
+    return (async () => {
+        await settleOrTimeout(predecessor);
+        queuedCount--;
+        try {
+            return await fn();
+        } finally {
+            release();
+        }
+    })();
+}
+
+/**
+ * Number of calls enqueued and still waiting for a turn. Deliberately excludes the call
+ * currently running, so a handler asking this question does not count itself: from inside
+ * `query_dirty` the answer is "how many mutations are still queued behind me", which is
+ * exactly what makes a `dirty: false` reading from the editor untrustworthy (#6).
+ */
+export function pendingMutationCount(): number {
+    return queuedCount;
+}
+
+/** Test-only: drop the chain so one suite's queue state cannot leak into the next. */
+export function resetMutationQueue(): void {
+    tail = Promise.resolve();
+    queuedCount = 0;
+}

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -127,6 +127,13 @@ export interface ActionToolExecutor {
     execute(action: string, args: Record<string, any>): Promise<ActionToolResult>;
     /** List of supported actions */
     readonly actions: string[];
+    /**
+     * Opt out of the global mutation serialization queue (#6). Only for tools that
+     * re-enter the dispatcher themselves (batch_execute) — enqueueing those would
+     * deadlock them behind their own queue slot. Omitted/false means serialized, so a
+     * newly added mutating tool is protected without having to remember to opt in.
+     */
+    readonly reentrant?: boolean;
 }
 
 /** Standardized tool result — replaces ad-hoc ToolResponse */


### PR DESCRIPTION
## What

Prevents the data loss in #6 at its root: every MCP tool call is now serialized on a single
promise chain, so a `manage_scene save` can no longer begin while a concurrently issued
`manage_node create` is still committing.

## Why

#59 (commit `00c3298`) fixed the *reporting* half of this issue — `save` now reads
`scene:save-scene`'s boolean and re-checks `scene:query-dirty`. Two of the three sub-defects
survived on `origin/main`, verified against source before starting:

- **The race itself was untouched.** Nothing serialized concurrent editor calls; no queue or
  serializer module existed anywhere under `source/tools/`. #59 detects a dropped edit after
  the fact, it does not prevent one.
- **`query_dirty` still misreported clean.** `source/tools/manage-scene-query.ts:100-108`
  proxied `scene:query-dirty` verbatim, with zero reconciliation against calls the client had
  issued but that had not reached the editor yet.
- **The three fixed commit-latency sleeps were still there** (`manage-node.ts` :245 `:266`
  `:285`) — the create path's own admission that a freshly created node is not immediately
  queryable, followed by proceeding regardless of whether the commit had landed.

## Option chosen (and why it was the conservative one)

The fix sketch proposed wrapping mutating calls in each of four tool files. I serialized at
**`MCPServer.executeToolCall`** instead — the single dispatch point every tool call already
passes through (verified: the only `executor.execute(` call site in the repo, and the only
`executeToolCall` consumer besides the HTTP handlers is `BatchExecute`). One seam instead of
four, and no per-tool "is this mutating?" allow-list to drift out of date.

The re-entrancy hazard that creates is handled by declaration, not by a hardcoded tool name:
a new additive `ActionToolExecutor.reentrant?: boolean` that `batch_execute` sets, because it
calls back into `executeToolCall` per entry and would otherwise park behind a slot only its
own inner calls can release. **Omitting the flag means serialized**, so a newly added mutating
tool is protected without anyone remembering to opt in.

Two liveness guards, since serializing raises blast radius: the chain slot is released in a
`finally` (a rejecting call cannot wedge the queue), and a queued call waits at most 120s for
its turn before proceeding unserialized with a warning, so a hung editor request cannot take
every later call down with it.

## Changes

| File | Change |
|---|---|
| `source/tools/mutation-queue.ts` (new) | `enqueueMutation` / `pendingMutationCount` / `resetMutationQueue` |
| `source/mcp-server.ts` | `executeToolCall` routes through the queue unless `executor.reentrant` |
| `source/types/index.ts` | additive `ActionToolExecutor.reentrant?: boolean` |
| `source/tools/batch-execute.ts` | declares `reentrant = true` |
| `source/tools/manage-scene-query.ts` | `query_dirty` reconciles the editor flag against the queue; reports `dirty`, `editorDirty`, `pendingMutations` |
| `source/tools/manage-node.ts` | three fixed sleeps → bounded `scene:query-node` poll (`awaitNodeCommit`) |
| `source/tools/manage-scene.ts` | comment only — the concurrency caveat it documented is now prevented upstream |

`query_dirty`'s `dirty` field keeps its meaning and only ever becomes *more* conservative;
`editorDirty` and `pendingMutations` are additive.

## Evidence / what I verified, and how

Every new test was confirmed **red before the fix**, not just green after:

- `mcp-server-serialization.test.ts` — reproduces the report's caller pattern (create + save
  fired together, neither awaited). Reverting the `executeToolCall` wiring: `● does not start
  a save while a concurrently issued node create is still committing / Expected: false /
  Received: true` — `save-scene` ran while `create-node` was still pending, i.e. the reported
  data loss.
- Same file, batch case — flipping `reentrant` to `false`: `thrown: "Exceeded timeout of
  5000 ms for a test"`, the deadlock the flag exists to prevent.
- `manage-node-commit-wait.test.ts` — restoring the `setTimeout(r, 100)` sleeps: both cases
  fail; `create-component` fires at a node `query-node` cannot yet see.
- `manage-scene-query-dirty.test.ts` — `query_dirty` reports `dirty: true` with calls queued
  while the editor flag reads `false`.

Full suite after: **43 suites / 702 tests, zero failures**; `tsc --noEmit` clean. No
pre-existing failures observed on this branch.

## Not verified here

Step 5 of the triage sketch asks for a live Cocos Creator 3.8.7 run (the report's RUN 1 and
march4th2001's six-prefab loop). I had no editor available, so that has **not** been done —
the evidence above is source-level plus the jest suite against the editor mock. Worth a live
pass before relying on this in anger.

## Remaining

The queue is process-local. It serializes calls arriving through this server; it cannot order
edits a human makes in the editor UI concurrently. That is out of scope for this issue.

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011k2Ayspd1FcbrfEZHJDB6u
